### PR TITLE
fix: add bundle vendor path to system path 

### DIFF
--- a/.github/workflows/node.js-ci.yml
+++ b/.github/workflows/node.js-ci.yml
@@ -38,17 +38,25 @@ jobs:
         ruby-version: 2.7 # Not needed with a .ruby-version file
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
+    # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-system-path
+    - name: Setup Custom PATH
+      run: |
+        echo "${GITHUB_WORKSPACE}/vendor/bundle" >> $GITHUB_PATH
+
     - name: Check install Hugo
       run: hugo version
 
+    - name: Check Asciidoctor install (from bundler)
+      run: asciidoctor --version
+
     - name: Install dependencies
       run: npm ci
-    
+
     - name: Check for linting errors
       run: npm test
-    
+
     - name: Delete temporary directories
       run: npm run clean
-    
+
     - name: Build production website
       run: npm run build


### PR DESCRIPTION
to allow access for asciidoctor CLI in CI

Signed-off-by: Damien Duportal <damien.duportal@gmail.com>