### PR TITLE
Clarify Dev server requirements and startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,22 +6,31 @@ Make sure all dependencies have been installed:
 
 - [Hugo](https://gohugo.io/getting-started/installing/) >= 0.75.0/extended (needed for SCSS processing support)
 - [Node.js](https://nodejs.org/) >= 14.15.0 (needed to install npm packages and run commands)
+- [Asciidoctor](https://asciidoctor.org/) >= 2.0.16 (needed to render the .adoc files with Hugo)
 
 ## Get started
 
 Have your local site in two steps:
 
-### 2. Install npm packages
+### 1. Install npm packages
 
 ```bash
 npm install
 ```
 
-### 3. Start local development server
+### 2. Start local development server
 
 ```bash
 npm run start
 ```
+
+### 3. Open the start page of the website
+
+Point your browser to `http://localhost:1313`
+
+### 4. Stopping the local development server
+
+`<ctrl><C>` in the session where the `npm run start` was executed.
 
 ## Other commands
 


### PR DESCRIPTION
In the README.md:

* Add the missing `asciidoctor` pre-requisite 
* Add more details on how to start the development web server locally.

Fixes issue #144 