### PR TITLE
remove docker-compose.yaml as it will not work with npm

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,9 +1,0 @@
-version: '3'
-services:
-  status:
-    image: klakegg/hugo:0.84.3-asciidoctor
-    volumes:
-      - .:/src
-    ports:
-        - 1313:1313
-    command: "serve --cleanDestinationDir --disableFastRender --path-warnings --print-mem --verbose --verboseLog --noHTTPCache"


### PR DESCRIPTION
Removing `docker-compose.yaml` as it is very likely a dead end. The dependency on NPM makes it very difficult to run with Docker.

Fixes issue #146 