### PR TITLE
cleanup(sources) remove mentions of the deprecated singular-source syntax

### DIFF
--- a/content/docs/core/condition.adoc
+++ b/content/docs/core/condition.adoc
@@ -80,7 +80,7 @@ The targets of this pipeline are not executed if this condition fails.
 
 [source,yaml]
 ----
-source:
+sources:
   tagVersion:
     kind: shell
     spec:

--- a/content/docs/core/source.adoc
+++ b/content/docs/core/source.adoc
@@ -6,10 +6,10 @@ date: 2021-01-09T15:21:01+02:00
 lastmod: 2021-01-09T15:21:01+02:00
 draft: false
 images: []
-menu: 
+menu:
   docs:
     parent: "core"
-weight: 130 
+weight: 130
 toc: true
 ---
 // <!-- Required for asciidoctor -->
@@ -27,11 +27,11 @@ The "source" stage retrieve an information from a third "resource" like a file, 
 |===
 | Name | Required | Default |Description
 | kind | &#10004; |-| Define the resource type used for the `spec`
-| name | &#10004; |-| Small description used in message, reports, etc. 
+| name | &#10004; |-| Small description used in message, reports, etc.
 | prefix |-|-| Define the prefix to be added to the retrieved information.
 | postfix |-|-| Define the postfix to be added to the retrieved information.
 | replaces |-|-| A list of replacer rules that modify the information retrieved from the resource
-| scm |-|-| Define source control management parameters, cfr to the scm 
+| scm |-|-| Define source control management parameters, cfr to the scm
 | spec | &#10004; |-| Define resource parameters, cfr to appropriated resource documentation
 |===
 
@@ -52,20 +52,19 @@ A replacer rule modify the information by replacing the "from" value by the "to"
 
 .updatecli.yaml
 ```
-source:
-  name: "Retrieve latest jenkins weekly version"
-  kind: githubRelease
-  prefix: "jenkins/jenkins:"
-  postfix: "-jdk11"
-  replaces:
-    - from: "jenkins-"
-      to: ""
-  spec:
-    owner: "jenkinsci"
-    repository: "jenkins"
-    token: "{{ requiredEnv .github.token }}" 
-    username: "{{ .github.username }}" 
-    version: "latest"
+sources:
+  lastJenkinsWeeklyVersion:
+    name: "Retrieve latest jenkins weekly version"
+    kind: githubRelease
+    prefix: "jenkins/jenkins:"
+    postfix: "-jdk11"
+    replaces:
+      - from: "jenkins-"
+        to: ""
+    spec:
+      owner: "jenkinsci"
+      repository: "jenkins"
+      version: "weekly"
 
 ## To be continued
 ```

--- a/content/docs/help/contributing.adoc
+++ b/content/docs/help/contributing.adoc
@@ -6,7 +6,7 @@ date: 2020-10-06T08:49:31+00:00
 lastmod: 2020-10-06T08:49:31+00:00
 draft: false
 images: []
-menu: 
+menu:
   docs:
     parent: "help"
 weight: 630
@@ -89,7 +89,7 @@ In the `main.go`, you need to define the `struct` that you'll use to configure y
 ```
 type Capitalized_package_name struct {
 	Field1        string
-	Field2        string 
+	Field2        string
 	Field3        string
 	Field4        string
 }
@@ -167,11 +167,12 @@ config.value
 ```
 # updatecli diff --config config.value
 
-source:
-  kind: packageName
-  spec:
-    field1: "value"
-    field3: "value"
+sources:
+  lastPackage:
+    kind: packageName
+    spec:
+      field1: "value"
+      field3: "value"
 targets:
   idName:
     name: "updatecli"

--- a/content/docs/plugins/docker_digest.adoc
+++ b/content/docs/plugins/docker_digest.adoc
@@ -6,10 +6,10 @@ date: 2021-01-09T15:21:01+02:00
 lastmod: 2021-01-09T15:21:01+02:00
 draft: false
 images: []
-menu: 
+menu:
   docs:
     parent: "plugins"
-weight: 130 
+weight: 130
 toc: true
 plugins:
   - source
@@ -75,11 +75,12 @@ The main motivation is to use {{ requiredEnv ENV_VARIABLE }} to read the github 
 
 updatecli.tpl
 ```
-source:
-  kind: dockerDigest
-  spec:
-    image: "jenkins/jenkins"
-    tag: "lts-jdk11"
+sources:
+  lastDockerDigest:
+    kind: dockerDigest
+    spec:
+      image: "jenkins/jenkins"
+      tag: "lts-jdk11"
 targets:
   imageTag:
     name: "jenkins/jenkins:lts-jdk11 docker digest"

--- a/content/docs/plugins/docker_image.adoc
+++ b/content/docs/plugins/docker_image.adoc
@@ -6,10 +6,10 @@ date: 2020-10-13T15:21:01+02:00
 lastmod: 2020-10-13T15:21:01+02:00
 draft: false
 images: []
-menu: 
+menu:
   docs:
     parent: "plugins"
-weight: 130 
+weight: 130
 toc: true
 plugins:
   - condition
@@ -77,14 +77,15 @@ The main motivation is to use {{ requiredEnv ENV_VARIABLE }} to read the github 
 .updatecli.tpl
 ```
 ---
-source:
-  kind: githubRelease
-  spec:
-    owner: "jenkins-infra"
-    repository: "plugin-site-api"
-    token: "{{ requiredEnv .github.token }}" 
-    username: "olblak"
-    version: "latest"
+sources:
+  lastGithubRelease:
+    kind: githubRelease
+    spec:
+      owner: "jenkins-infra"
+      repository: "plugin-site-api"
+      token: "{{ requiredEnv .github.token }}"
+      username: "olblak"
+      version: "latest"
 conditions:
   docker:
     name: "Docker Image Published on Registry"
@@ -100,11 +101,11 @@ targets:
       key: "backend.image.tag"
     scm:
       github:
-        user: "{{ .github.user }}" 
-        email: "{{ .github.email }}" 
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
         owner: "jenkins-infra"
         repository: "charts"
-        token: "{{ requiredEnv .github.token }}" 
+        token: "{{ requiredEnv .github.token }}"
         username: "olblak"
         branch: "master"
 ```

--- a/content/docs/plugins/dockerfile.adoc
+++ b/content/docs/plugins/dockerfile.adoc
@@ -348,15 +348,16 @@ When used as a target (and writing to a file):
 
 .updatecli.yaml
 ```
-source:
-  name: Get Latest helm release version
-  kind: githubRelease
-  spec:
-    owner: "helm"
-    repository: "helm"
-    token: {{ requiredEnv .github.token }}
-    username: olblak
-    version: latest
+sources:
+  lastHelmVersion:
+    name: Get Latest helm release version
+    kind: githubRelease
+    spec:
+      owner: "helm"
+      repository: "helm"
+      token: {{ requiredEnv .github.token }}
+      username: olblak
+      version: latest
 conditions:
   isENVSet:
     name: Is ENV HELM_VERSION set

--- a/content/docs/plugins/github_release.adoc
+++ b/content/docs/plugins/github_release.adoc
@@ -6,10 +6,10 @@ date: 2021-01-09T15:21:01+02:00
 lastmod: 2021-01-09T15:21:01+02:00
 draft: false
 images: []
-menu: 
+menu:
   docs:
     parent: "plugins"
-weight: 130 
+weight: 130
 toc: true
 plugins:
   - source
@@ -58,30 +58,32 @@ It's considered a very bad practice to store credentials in an un-encrypted file
 Consider using an environment variable to store the token.
 
 ```
-source:
-  kind: githubRelease
-  spec:
-    owner: "jenkins-infra"
-    repository: "jenkins-wiki-exporter"
-    token: "{{ requiredEnv "ENV_VARIABLE" }}"
-    username: "john"
-    version: "v1.10"
+sources:
+  lastRelease:
+    kind: githubRelease
+    spec:
+      owner: "jenkins-infra"
+      repository: "jenkins-wiki-exporter"
+      token: "{{ requiredEnv "ENV_VARIABLE" }}"
+      username: "john"
+      version: "v1.10"
 ```
 => Return v1.10.3
 
-== Example 
+== Example
 
 .updatecli.yaml
 ```
-source:
-  name: Get Latest helm release version
-  kind: githubRelease
-  spec:
-    owner: "helm"
-    repository: "helm"
-    token: {{ requiredEnv .github.token }}
-    username: olblak
-    version: latest
+sources:
+  lastRelease:
+    name: Get Latest helm release version
+    kind: githubRelease
+    spec:
+      owner: "helm"
+      repository: "helm"
+      token: {{ requiredEnv .github.token }}
+      username: olblak
+      version: latest
 conditions:
   isENVSet:
     name: Is ENV HELM_VERSION set
@@ -127,8 +129,8 @@ Retrieve the latest helm version from its Github release located on https://gith
 *Conditions*
 
 Then it tests one condition:
-If the dockerfile 'docker/Dockerfile' is located on the git repository https://github.com/olblak/charts 
-has the instruction ENV[1][0] set to "HELM_VERSION". ENV[1][0] is a custom syntax to represent 
+If the dockerfile 'docker/Dockerfile' is located on the git repository https://github.com/olblak/charts
+has the instruction ENV[1][0] set to "HELM_VERSION". ENV[1][0] is a custom syntax to represent
 a two-dimensional array where the first element represents a specific Dockerfile instruction identifier
 starting from "0" at the beginning of the document, so we are looking for the second INSTRUCTION "ENV".
 The second element represents an instruction argument position. In this case, we want to check that ENV key
@@ -136,7 +138,7 @@ is set to "HELM_VERSION"
 
 *Targets*
 
-If the condition is met, which is to be sure that the ENV key set to "HELM_VERSION" exist, then we'll 
+If the condition is met, which is to be sure that the ENV key set to "HELM_VERSION" exist, then we'll
 are going to update its value if needed based on the version retrieved from the source.
 The syntax is the same for the condition excepted that this time we are looking for ENV[1][1]
 which means that the second argument of the second ENV instruction.

--- a/content/docs/plugins/helm_chart.adoc
+++ b/content/docs/plugins/helm_chart.adoc
@@ -6,10 +6,10 @@ date: 2021-01-09T15:21:01+02:00
 lastmod: 2021-01-09T15:21:01+02:00
 draft: false
 images: []
-menu: 
+menu:
   docs:
     parent: "plugins"
-weight: 130 
+weight: 130
 toc: true
 plugins:
   - source
@@ -35,7 +35,7 @@ The Helm chart "source" retrieves the latest version of a Helm package.
 
 **condition**
 
-The Helm chart "condition" tests if a helm chart release exist. 
+The Helm chart "condition" tests if a helm chart release exist.
 
 **target**
 
@@ -51,7 +51,7 @@ The Helm chart "target" updates a helmchart and bump the chart metadata. It hand
 | version | &#10004; | Source | [S,C] Define Helm chart version.
 | file| | values.yaml |[T] Define the file that needs to be updated
 | value| | source | [T] Define the value that need to be present in helm chart file
-| key | &#10004; | - | [T] Define the key that need to be present in helm chart file 
+| key | &#10004; | - | [T] Define the key that need to be present in helm chart file
 | appversion | | false | [T] Boolean that defines if the value should also be used for the AppVersion
 | versionincrement| | minor | [T] Define the rule to automatically increment the helm chart version. It accept a comma separated list of major,minor,patch.
 |===
@@ -60,11 +60,12 @@ The Helm chart "target" updates a helmchart and bump the chart metadata. It hand
 
 .updatecli.yaml
 ```
-source:
-  kind: helmChart
-  spec:
-    url: https://charts.jenkins.io
-    name: jenkins
+sources:
+  lastRelease:
+    kind: helmChart
+    spec:
+      url: https://charts.jenkins.io
+      name: jenkins
 conditions:
   isPrometheuseHelmChartVersionAvailable:
     name: "Test if the prometheus helm chart is available"

--- a/content/docs/plugins/jenkins.adoc
+++ b/content/docs/plugins/jenkins.adoc
@@ -29,11 +29,11 @@ plugins:
 
 == Description
 
-**source**  
+**source**
 
-The jenkins "source" retrieves the latest version for a specific Jenkins release 
+The jenkins "source" retrieves the latest version for a specific Jenkins release
 
-**condition**  
+**condition**
 
 The jenkins "condition" test that a version exists and also that the version corresponds to a specific release type
 
@@ -67,14 +67,12 @@ To apply this update strategy, we can run the following command
 .updatecli.tpl
 ```
 ---
-source:
-  # Get latest jenkins weekly version with changelog from github
-  kind: jenkins
-  spec:
-    release: weekly
-    github:
-      token: {{ requiredEnv .github.token }}
-      username: {{ .github.username }}
+sources:
+  lastWeeklyRelease:
+    # Get latest jenkins weekly version with changelog from github
+    kind: jenkins
+    spec:
+      release: weekly
 conditions:
   # Test that a specific Jenkins version exists
   jenkinsVersion:
@@ -100,7 +98,7 @@ conditions:
         branch: main
         user: alice
         email: alice@example.com
-  # Test that there is a docker image with the correct tag 
+  # Test that there is a docker image with the correct tag
   # set to "<version>-jdk11"
   dockerImage:
     kind: dockerImage

--- a/content/docs/plugins/yaml.adoc
+++ b/content/docs/plugins/yaml.adoc
@@ -6,10 +6,10 @@ date: 2021-01-09T15:21:01+02:00
 lastmod: 2021-01-09T15:21:01+02:00
 draft: false
 images: []
-menu: 
+menu:
   docs:
     parent: "plugins"
-weight: 130 
+weight: 130
 toc: true
 plugins:
   - source
@@ -77,11 +77,12 @@ NOTE: Arrays can also be grouped with dots like `key.array[3].key`
 
 .updatecli.yaml
 ```
-source:
-  kind: helmChart
-  spec:
-    url: https://charts.jenkins.io
-    name: jenkins
+sources:
+  lastRelease:
+    kind: helmChart
+    spec:
+      url: https://charts.jenkins.io
+      name: jenkins
 conditions:
   isPrometheuseHelmChartVersionAvailable:
     name: "Test if the prometheus helm chart is available"
@@ -145,4 +146,3 @@ Then it tests two conditions.
 If conditions are all met, then updatecli will update (if needed) the first element of the key
 "dependencies" to "2.7.1" for the file "charts/jenkins/requirements.yaml"
 from the github repository olblak/chart then publish changes using a Github Pull Request targeting the master from a temporary branch.
-


### PR DESCRIPTION

## Description

The syntax of the updatecli YAML manifest does not support the top-level `source:` (aka. singular source) keyword anymore.
It was deprecated more than 1 year ago and https://github.com/updatecli/updatecli/pull/589 totally removes its support from updatecli.
