### PR TITLE
Bump updatecli workflow version to 1.30.0

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Diff
-        uses: updatecli/updatecli-action@v1.29.0
+        uses: updatecli/updatecli-action@v1.30.0
         with:
           command: diff
           flags: "--config ./updatecli/updatecli.d"
@@ -32,7 +32,7 @@ jobs:
           app_id: ${{ secrets.UPDATECLIBOT_APP_ID }}
           private_key: ${{ secrets.UPDATECLIBOT_APP_PRIVKEY }}
       - name: Apply
-        uses: updatecli/updatecli-action@v1.28.0
+        uses: updatecli/updatecli-action@v1.30.0
         if: github.ref == 'refs/heads/master'
         with:
           command: apply


### PR DESCRIPTION
Don't wait for dependabot to bump updatecli workflow

## Description

<!-- Describe the changes introduced by this pull request -->

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
