### PR TITLE
Hide plausible script behind netlify proxy

### DIFF
--- a/layouts/index.headers
+++ b/layouts/index.headers
@@ -2,7 +2,7 @@
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
   X-Content-Type-Options: nosniff
   X-XSS-Protection: 1; mode=block
-  Content-Security-Policy: default-src 'self' https://asciinema.org; frame-ancestors https://jamstackthemes.dev; manifest-src 'self'; connect-src 'self' https://plausible.io; font-src 'self'; img-src 'self' data:; script-src 'self' https://plausible.io https://asciinema.org 'unsafe-inline'; style-src 'self'
+  Content-Security-Policy: default-src 'self' https://asciinema.org; frame-ancestors https://jamstackthemes.dev; manifest-src 'self'; connect-src 'self' https://plausible.io; font-src 'self'; img-src 'self' data:; script-src 'self' https://plausible.io https://asciinema.org https://www.updatecli.io 'unsafe-inline'; style-src 'self'
   X-Frame-Options: SAMEORIGIN
   Referrer-Policy: strict-origin
   Feature-Policy: geolocation 'self'

--- a/layouts/partials/head/head.html
+++ b/layouts/partials/head/head.html
@@ -7,5 +7,5 @@
   {{ block "head/seo" . }}{{ partial "head/seo.html" . }}{{ end }}
   {{ block "head/favicons" . }}{{ partial "head/favicons.html" . }}{{ end }}
   {{ block "head/script-header" . }}{{ partial "head/script-header.html" . }}{{ end }}
-  <script async defer data-domain="updatecli.io"  src="https://plausible.io/js/plausible.js"></script>
+  <script async defer file-types="json,yaml,gz" data-domain="updatecli.io"  src="https://www.updatecli.io/js/script.file-downloads.outbound-links.js"></script>
 </head>

--- a/netlify.toml
+++ b/netlify.toml
@@ -15,3 +15,20 @@
 
 [context.branch-deploy]
   command = "hugo -b $DEPLOY_PRIME_URL --gc --minify"
+
+## A significant amount traffic is not detected by plausible
+## https://plausible.io/blog/google-analytics-adblockers-missing-data
+## https://plausible.io/docs/proxy/guides/netlify
+## https://docs.netlify.com/routing/redirects/
+[[redirects]]
+  from = "/js/script.file-downloads.outbound-links.js"
+  to = "https://plausible.io/js/script.file-downloads.outbound-links.js"
+  status = 200
+  force = true
+
+[[redirects]]
+  from = "/api/event"
+  to = "https://plausible.io/api/event"
+  status = 200
+  force = true
+

--- a/netlify.toml
+++ b/netlify.toml
@@ -31,4 +31,3 @@
   to = "https://plausible.io/api/event"
   status = 200
   force = true
-


### PR DESCRIPTION
I recently noticed that most of the traffic is not detected by plausible...

Signed-off-by: Olblak <me@olblak.com>

## Description

Hide plausible script behind netlify proxy as explained on https://plausible.io/docs/proxy/introduction

## Test

To test this pull request, you can look to the preview environment

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
