### PR TITLE
Updatecli/manifest/nodehugo

### DIFF
--- a/updatecli/updatecli.d/hugo.yaml
+++ b/updatecli/updatecli.d/hugo.yaml
@@ -42,7 +42,7 @@ targets:
     spec:
       file: ".github/workflows/build.yaml"
       matchpattern: 'hugo-version: (.*)'
-      replacepattern: 'node-version: {{ source "hugo" }}'
+      replacepattern: 'hugo-version: {{ source "hugo" }}'
 
 pullrequests:
   default:

--- a/updatecli/updatecli.d/hugo.yaml
+++ b/updatecli/updatecli.d/hugo.yaml
@@ -34,6 +34,16 @@ targets:
       matchpattern: 'HUGO_VERSION = "(.*)"'
       replacepattern: 'HUGO_VERSION = "{{ source "hugo" }}"'
 
+  githubaction:
+    name: Update Hugo version used in Github Action
+    kind: file
+    scmid: "default"
+    sourceid: hugo
+    spec:
+      file: ".github/workflows/build.yaml"
+      matchpattern: 'hugo-version: (.*)'
+      replacepattern: 'node-version: {{ source "hugo" }}'
+
 pullrequests:
   default:
     title: '[updatecli] Bump HUGO to {{ source "hugo" }}'
@@ -41,6 +51,7 @@ pullrequests:
     scmid: "default"
     targets:
       - "netlify"
+      - "githubaction"
     spec:
       automerge: true
       mergemethod: "squash"

--- a/updatecli/updatecli.d/node.yaml
+++ b/updatecli/updatecli.d/node.yaml
@@ -21,18 +21,45 @@ sources:
       repository: "node"
       token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
+      versionfilter:
+        kind: semver
+        pattern: "~16"
+
+  majornodeversion:
+    name: "Get latest HUGO version"
+    kind: "githubrelease"
+    spec:
+      owner: "nodejs"
+      repository: "node"
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
+      versionfilter:
+        kind: semver
+        pattern: "~16"
     transformers:
-      - trimPrefix: "v"
+      - findSubMatch:
+          pattern: '^(\d*)'
 
 targets:
   netlify:
     name: Update Node version used on Netlify
     kind: file
     scmid: "default"
+    sourceid: node
     spec:
       file: "netlify.toml"
       matchpattern: 'NODE_VERSION = "(.*)"'
       replacepattern: 'NODE_VERSION = "{{ source "node" }}"'
+
+  githubaction:
+    name: Update Node version used in Github Action
+    kind: file
+    scmid: "default"
+    sourceid: majornodeversion
+    spec:
+      file: ".github/workflows/build.yaml"
+      matchpattern: 'node-version: (.*)'
+      replacepattern: 'node-version: {{ source "majornodeversion" }}'
 
 pullrequests:
   default:
@@ -41,6 +68,7 @@ pullrequests:
     scmid: "default"
     targets:
       - "netlify"
+      - "githubaction"
     spec:
       automerge: true
       mergemethod: "squash"


### PR DESCRIPTION
Update updatecli manifest for Hugo and node to also bump version used in Github Action