### PR TITLE
Reorganize plugin menu

### DIFF
--- a/config/_default/menus/menus.en.toml
+++ b/config/_default/menus/menus.en.toml
@@ -29,6 +29,28 @@
   url = "/plugins/"
 
 [[docs]]
+  name = "resource"
+  weight = 25
+  identifier = "plugin-resource"
+  url = "/plugins/resource/"
+  parent= "plugins"
+
+[[docs]]
+  name = "pullrequest"
+  weight = 25
+  identifier = "plugin-pullrequest"
+  url = "/plugins/pullrequest/"
+  parent= "plugins"
+
+[[docs]]
+  name = "scm"
+  weight = 25
+  identifier = "plugin-scm"
+  url = "/plugins/scm/"
+  parent= "plugins"
+
+
+[[docs]]
   name = "Automate"
   identifier = "automate"
   url = "/docs/automate"

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -111,5 +111,5 @@ lastMod = true
 
 [menu]
   [menu.section]
-    auto = true
+    auto = false
     collapsibleSidebar = true

--- a/content/en/docs/plugins/pullrequest/github.adoc
+++ b/content/en/docs/plugins/pullrequest/github.adoc
@@ -1,15 +1,15 @@
 ---
-title: "Github PullRequest"
-description: "Interact with Github PullRequest"
+title: "Github"
+description: "Manipulate Github PullRequest"
 lead: "kind: github"
 date: 2022-01-30T08:21:01+02:00
 lastmod: 2022-01-30T08:21:01+02:00
 draft: false
 images: []
-menu: 
+menu:
   docs:
-    parent: "plugins"
-weight: 130 
+    parent: "plugin-pullrequest"
+weight: 130
 toc: true
 plugins:
   - pullrequest
@@ -38,7 +38,7 @@ The `pullrequests` section describes the link:https://docs.github.com/en/pull-re
 | title | | "" | Set the pull request title
 |===
 
-== Example 
+== Example
 
 [source,yaml]
 ----

--- a/content/en/docs/plugins/resource/aws_ami.adoc
+++ b/content/en/docs/plugins/resource/aws_ami.adoc
@@ -8,7 +8,7 @@ draft: false
 images: []
 menu:
   docs:
-    parent: "plugins"
+    parent: "plugin-resource"
 weight: 130
 toc: true
 plugins:

--- a/content/en/docs/plugins/resource/docker_digest.adoc
+++ b/content/en/docs/plugins/resource/docker_digest.adoc
@@ -1,36 +1,35 @@
 ---
-title: "Docker Image"
-description: "Manipulate information from docker image"
-lead: "kind: dockerImage"
-date: 2020-10-13T15:21:01+02:00
-lastmod: 2020-10-13T15:21:01+02:00
+title: "Docker Digest"
+description: "Manipulate Docker Image digest"
+lead: "kind: dockerDigest"
+date: 2021-01-09T15:21:01+02:00
+lastmod: 2021-01-09T15:21:01+02:00
 draft: false
 images: []
 menu:
   docs:
-    parent: "plugins"
+    parent: "plugin-resource"
 weight: 130
 toc: true
 plugins:
-  - condition
+  - source
 ---
 // <!-- Required for asciidoctor -->
 :toc:
 // Set toclevels to be at least your hugo [markup.tableOfContents.endLevel] config key
 :toclevels: 4
 
-
 [cols="1^,1^,1^",options=header]
 |===
-| source | condition | target
-| &#10007; | &#10004; | &#10007;
+| source | condition | target | scm
+| &#10004; | &#10007; | &#10007; | &#10007;
 |===
 
 == Description
 
-**condition**
+**source**
 
-The Docker Image "condition" tests if a docker image tag exist on a Docker Registry
+The Docker Digest "source" retrieves the Docker image digest for a specific Docker image tag.
 
 == Parameters
 
@@ -38,9 +37,9 @@ The Docker Image "condition" tests if a docker image tag exist on a Docker Regis
 |===
 | Name | Required | Default |Description
 | hostname| | hub.docker.com | Docker Registry URL. Accept "hub.docker.com", "ghcr.io", "quay.io", or any valid api compliant OCI registry
-| image | &#10004; | - | Define docker image name
-| tag | | Source output | Define docker image tag.
-| token | | - | Define the token needed to authenticate with the docker registry
+| image | &#10004; | - | Define Docker image name
+| tag | &#10004; | source result | Define Docker image tag.
+| token | | - | Define the token needed to authenticate with the Docker registry
 |===
 
 **Remark**:
@@ -58,7 +57,7 @@ Github uses personal access token. How to retrieve one, is explained https://doc
 
 === DockerHub
 
-To retrieve the token, it's easier to run `docker login` and then retrieve the token stored in '~/.docker/config.json'
+To retrieve a token, it's easier to run `docker login` and then retrieve the token stored in '~/.docker/config.json'
 
 .~/.docker/config.json
 ```
@@ -74,32 +73,21 @@ To retrieve the token, it's easier to run `docker login` and then retrieve the t
 Please note that in this example we are using a go template `updatecli.tpl` with values from `values.yaml`
 The main motivation is to use {{ requiredEnv ENV_VARIABLE }} to read the github token from a environment variable.
 
-.updatecli.tpl
+updatecli.tpl
 ```
----
 sources:
-  lastGithubRelease:
-    kind: githubRelease
+  lastDockerDigest:
+    kind: dockerDigest
     spec:
-      owner: "jenkins-infra"
-      repository: "plugin-site-api"
-      token: "{{ requiredEnv .github.token }}"
-      username: "olblak"
-      versionFilter:
-        kind: latest
-conditions:
-  docker:
-    name: "Docker Image Published on Registry"
-    kind: dockerImage
-    spec:
-      image: "jenkinsciinfra/plugin-site-api"
+      image: "jenkins/jenkins"
+      tag: "lts-jdk11"
 targets:
   imageTag:
-    name: "jenkinsciinfra/plugin-site-api docker image"
+    name: "jenkins/jenkins:lts-jdk11 docker digest"
     kind: yaml
     spec:
-      file: "charts/plugin-site/values.yaml"
-      key: "backend.image.tag"
+      file: "config/default/jenkins-release.yaml"
+      key: "jenkins.master.imageTag"
     scm:
       github:
         user: "{{ .github.user }}"
@@ -107,7 +95,7 @@ targets:
         owner: "jenkins-infra"
         repository: "charts"
         token: "{{ requiredEnv .github.token }}"
-        username: "olblak"
+        username: "{{ .github.username }}"
         branch: "master"
 ```
 
@@ -126,12 +114,10 @@ github:
 What it says:
 
 **Source**
-Retrieve the latest version from the Github release of the project jenkis-infra/plugins-site-api
-=> v1.11.1
+Retrieve the Docker image digest for the image `jenkins/jenkins` with the tag `lts-jdk11` from DockerHub
 
-**Condtion**
-Test that the tag `v1.11.1` exist for the image `jenkinsciinfra/plugin-site-api` on DockerHub
-=> No, then abort
+**Conditions**
+No condition specified
 
-**target**
-If the condition was passsing then it would have update the key `backend.image.tag` in the yaml file `charts/plugin-site/values.yaml` located on the Github repository `olblak/charts` on the branch `master` using the Github Pull request workflow
+**Targets**
+Update the yaml key `jenkins.master.imageTag` in the file `config/default/jenkins-release.yaml` located on the Github repository `olblak/charts`

--- a/content/en/docs/plugins/resource/docker_image.adoc
+++ b/content/en/docs/plugins/resource/docker_image.adoc
@@ -1,35 +1,36 @@
 ---
-title: "Docker Digest"
-description: "Manipulate Docker Image digest"
-lead: "kind: dockerDigest"
-date: 2021-01-09T15:21:01+02:00
-lastmod: 2021-01-09T15:21:01+02:00
+title: "Docker Image"
+description: "Manipulate information from docker image"
+lead: "kind: dockerImage"
+date: 2020-10-13T15:21:01+02:00
+lastmod: 2020-10-13T15:21:01+02:00
 draft: false
 images: []
 menu:
   docs:
-    parent: "plugins"
+    parent: "plugin-resource"
 weight: 130
 toc: true
 plugins:
-  - source
+  - condition
 ---
 // <!-- Required for asciidoctor -->
 :toc:
 // Set toclevels to be at least your hugo [markup.tableOfContents.endLevel] config key
 :toclevels: 4
 
+
 [cols="1^,1^,1^",options=header]
 |===
-| source | condition | target | scm
-| &#10004; | &#10007; | &#10007; | &#10007;
+| source | condition | target
+| &#10007; | &#10004; | &#10007;
 |===
 
 == Description
 
-**source**
+**condition**
 
-The Docker Digest "source" retrieves the Docker image digest for a specific Docker image tag.
+The Docker Image "condition" tests if a docker image tag exist on a Docker Registry
 
 == Parameters
 
@@ -37,9 +38,9 @@ The Docker Digest "source" retrieves the Docker image digest for a specific Dock
 |===
 | Name | Required | Default |Description
 | hostname| | hub.docker.com | Docker Registry URL. Accept "hub.docker.com", "ghcr.io", "quay.io", or any valid api compliant OCI registry
-| image | &#10004; | - | Define Docker image name
-| tag | &#10004; | source result | Define Docker image tag.
-| token | | - | Define the token needed to authenticate with the Docker registry
+| image | &#10004; | - | Define docker image name
+| tag | | Source output | Define docker image tag.
+| token | | - | Define the token needed to authenticate with the docker registry
 |===
 
 **Remark**:
@@ -57,7 +58,7 @@ Github uses personal access token. How to retrieve one, is explained https://doc
 
 === DockerHub
 
-To retrieve a token, it's easier to run `docker login` and then retrieve the token stored in '~/.docker/config.json'
+To retrieve the token, it's easier to run `docker login` and then retrieve the token stored in '~/.docker/config.json'
 
 .~/.docker/config.json
 ```
@@ -73,21 +74,32 @@ To retrieve a token, it's easier to run `docker login` and then retrieve the tok
 Please note that in this example we are using a go template `updatecli.tpl` with values from `values.yaml`
 The main motivation is to use {{ requiredEnv ENV_VARIABLE }} to read the github token from a environment variable.
 
-updatecli.tpl
+.updatecli.tpl
 ```
+---
 sources:
-  lastDockerDigest:
-    kind: dockerDigest
+  lastGithubRelease:
+    kind: githubRelease
     spec:
-      image: "jenkins/jenkins"
-      tag: "lts-jdk11"
+      owner: "jenkins-infra"
+      repository: "plugin-site-api"
+      token: "{{ requiredEnv .github.token }}"
+      username: "olblak"
+      versionFilter:
+        kind: latest
+conditions:
+  docker:
+    name: "Docker Image Published on Registry"
+    kind: dockerImage
+    spec:
+      image: "jenkinsciinfra/plugin-site-api"
 targets:
   imageTag:
-    name: "jenkins/jenkins:lts-jdk11 docker digest"
+    name: "jenkinsciinfra/plugin-site-api docker image"
     kind: yaml
     spec:
-      file: "config/default/jenkins-release.yaml"
-      key: "jenkins.master.imageTag"
+      file: "charts/plugin-site/values.yaml"
+      key: "backend.image.tag"
     scm:
       github:
         user: "{{ .github.user }}"
@@ -95,7 +107,7 @@ targets:
         owner: "jenkins-infra"
         repository: "charts"
         token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
+        username: "olblak"
         branch: "master"
 ```
 
@@ -114,10 +126,12 @@ github:
 What it says:
 
 **Source**
-Retrieve the Docker image digest for the image `jenkins/jenkins` with the tag `lts-jdk11` from DockerHub
+Retrieve the latest version from the Github release of the project jenkis-infra/plugins-site-api
+=> v1.11.1
 
-**Conditions**
-No condition specified
+**Condtion**
+Test that the tag `v1.11.1` exist for the image `jenkinsciinfra/plugin-site-api` on DockerHub
+=> No, then abort
 
-**Targets**
-Update the yaml key `jenkins.master.imageTag` in the file `config/default/jenkins-release.yaml` located on the Github repository `olblak/charts`
+**target**
+If the condition was passsing then it would have update the key `backend.image.tag` in the yaml file `charts/plugin-site/values.yaml` located on the Github repository `olblak/charts` on the branch `master` using the Github Pull request workflow

--- a/content/en/docs/plugins/resource/dockerfile.adoc
+++ b/content/en/docs/plugins/resource/dockerfile.adoc
@@ -8,7 +8,7 @@ draft: false
 images: []
 menu:
   docs:
-    parent: "plugins"
+    parent: "plugin-resource"
 weight: 130
 toc: true
 plugins:

--- a/content/en/docs/plugins/resource/file.adoc
+++ b/content/en/docs/plugins/resource/file.adoc
@@ -8,7 +8,7 @@ draft: false
 images: []
 menu:
   docs:
-    parent: "plugins"
+    parent: "plugin-resource"
 weight: 130
 toc: true
 plugins:

--- a/content/en/docs/plugins/resource/gitTag.adoc
+++ b/content/en/docs/plugins/resource/gitTag.adoc
@@ -8,7 +8,7 @@ draft: false
 images: []
 menu:
   docs:
-    parent: "plugins"
+    parent: "plugin-resource"
 weight: 130
 toc: true
 plugins:

--- a/content/en/docs/plugins/resource/github_release.adoc
+++ b/content/en/docs/plugins/resource/github_release.adoc
@@ -8,7 +8,7 @@ draft: false
 images: []
 menu:
   docs:
-    parent: "plugins"
+    parent: "plugin-resource"
 weight: 130
 toc: true
 plugins:

--- a/content/en/docs/plugins/resource/helm_chart.adoc
+++ b/content/en/docs/plugins/resource/helm_chart.adoc
@@ -8,7 +8,7 @@ draft: false
 images: []
 menu:
   docs:
-    parent: "plugins"
+    parent: "plugin-resource"
 weight: 130
 toc: true
 plugins:

--- a/content/en/docs/plugins/resource/jenkins.adoc
+++ b/content/en/docs/plugins/resource/jenkins.adoc
@@ -8,7 +8,7 @@ draft: false
 images: []
 menu:
   docs:
-    parent: "plugins"
+    parent: "plugin-resource"
 weight: 131
 toc: true
 plugins:

--- a/content/en/docs/plugins/resource/maven.adoc
+++ b/content/en/docs/plugins/resource/maven.adoc
@@ -8,7 +8,7 @@ draft: false
 images: []
 menu:
   docs:
-    parent: "plugins"
+    parent: "plugin-resource"
 weight: 130
 toc: true
 plugins:

--- a/content/en/docs/plugins/resource/shell.adoc
+++ b/content/en/docs/plugins/resource/shell.adoc
@@ -8,7 +8,7 @@ draft: false
 images: []
 menu:
   docs:
-    parent: "plugins"
+    parent: "plugin-resource"
 weight: 130
 toc: true
 plugins:

--- a/content/en/docs/plugins/resource/yaml.adoc
+++ b/content/en/docs/plugins/resource/yaml.adoc
@@ -8,7 +8,7 @@ draft: false
 images: []
 menu:
   docs:
-    parent: "plugins"
+    parent: "plugin-resource"
 weight: 130
 toc: true
 plugins:

--- a/content/en/docs/plugins/scm/git.adoc
+++ b/content/en/docs/plugins/scm/git.adoc
@@ -6,10 +6,10 @@ date: 2021-01-09T15:21:01+02:00
 lastmod: 2021-05-02T20:44:01+02:00
 draft: false
 images: []
-menu: 
+menu:
   docs:
-    parent: "plugins"
-weight: 130 
+    parent: "plugin-scm"
+weight: 130
 toc: true
 plugins:
   - scm

--- a/content/en/docs/plugins/scm/github.adoc
+++ b/content/en/docs/plugins/scm/github.adoc
@@ -1,15 +1,15 @@
 ---
-title: "Github"
+title: "Github "
 description: "Interact with github repositories"
 lead: "kind: github"
 date: 2021-01-09T15:21:01+02:00
 lastmod: 2021-01-09T15:21:01+02:00
 draft: false
 images: []
-menu: 
+menu:
   docs:
-    parent: "plugins"
-weight: 130 
+    parent: "plugin-scm"
+weight: 130
 toc: true
 plugins:
   - scm


### PR DESCRIPTION
## Description

The number of plugin is growing and it's getting difficult to know where to look after information.
I am reorganizing from 

* plugins 

to 
* plugins
  * scm
  * resource
  * pullrequest (need to be renamed to action)
  * autodiscovery (coming in a later pr)

## Test

To test this pull request, a preview environment is available to visualize the change

## Additional Information

### Tradeoff

Hugo requires menu entry to uniqu which is annoying as Github appears both in pullrequest and scm. I trick Hugo by introducing empty space in some plugin title 

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
