### PR TITLE
Fix wrong values file example in core/configuration

### DIFF
--- a/assets/code_example/docs/core/configuration/values.yaml
+++ b/assets/code_example/docs/core/configuration/values.yaml
@@ -1,1 +1,2 @@
-token: yourGithubToken
+github:
+  token: yourGithubToken


### PR DESCRIPTION
<!-- Provide a link to the documentation related to this this pull request -->
[Documentation](https://www.updatecli.io/docs/core/configuration/#_content)

## Description

config file references:

```
      token: "{{ .github.token }}"
```

but the values file only contains a single `token` key in the root