### PR TITLE
Update deprecate sourceid syntax in file guide

### DIFF
--- a/content/en/docs/plugins/resource/file.adoc
+++ b/content/en/docs/plugins/resource/file.adoc
@@ -250,7 +250,7 @@ or fails the pipeline (and never run the pipeline's targets).
 The "Input Value" is the string to compare with the specified file content.
 
 By default, the input value is set to the input source value associated to the condition
-(e.g. either the source specified with the `sourceID` attribute or the only source if the pipeline only have one).
+(e.g. either the source specified with the `sourceid` attribute or the only source if the pipeline only have one).
 
 Alternatively you can disable the source input value with `disablesourceinput: true` and specify a custom content  with the `spec.content` attribute (see examples below).
 
@@ -274,7 +274,7 @@ the value of the source named `ContentFromURL`:
 conditions:
   LocalFileHasSameContentAsSource:
     kind: file
-    sourceID: ContentFromURL
+    sourceid: ContentFromURL
     spec:
       file: LICENSE
 --
@@ -304,7 +304,7 @@ the value of the source named `checksums`:
 conditions:
   URLHasSameContentAsSource:
     kind: file
-    sourceID: checksums
+    sourceid: checksums
     spec:
       file: https://releases.hashicorp.com/terraform/0.14.5/terraform_0.14.5_SHA256SUMS
 --
@@ -433,7 +433,7 @@ you can specify the `spec.forcecreate` attribute to `true`.
 The "Input Value" is the string to write to the specified file.
 
 * By default, the input value is set to the input source value associated to the target
-(e.g. either the source specified with the `sourceID` attribute or the only source if the pipeline only have one).
+(e.g. either the source specified with the `sourceid` attribute or the only source if the pipeline only have one).
 
 * You can also specify a custom content with the `spec.content` attribute instead of using the input source value.
 Using the `spec.content` is useful when you need to templatize with the source input value (see example below).
@@ -465,7 +465,7 @@ You may restrict which part of the specified file to be updated with the input v
 targets:
   setFileContent:
     kind: file
-    sourceID: generatedReadMeContent
+    sourceid: generatedReadMeContent
     spec:
       file: README.md
       forcecreate: true
@@ -503,7 +503,7 @@ In this example, is defines a new version from the input source named `getMavenV
 targets:
   updateCopyrightYear:
     kind: file
-    sourceID: getMavenVersion # Source Value is "3.8.3"
+    sourceid: getMavenVersion # Source Value is "3.8.3"
     spec:
       file: versions.txt
       line: 3
@@ -542,7 +542,7 @@ the string `Copyright (c) 2021 $2` where `$2` is the content right-matched by `(
 targets:
   updateCopyrightYear:
     kind: file
-    sourceID: whateverSource # Will be ignored as `replacepattern` is specified
+    sourceid: whateverSource # Will be ignored as `replacepattern` is specified
     spec:
       file: LICENSE
       matchPattern: 'Copyright \(c\) (\d*) (.*)'
@@ -608,7 +608,7 @@ sources:
 conditions:
   LocalFileHasSameContentAsSource:
     kind: file
-    sourceID: ContentFromLocalFile
+    sourceid: ContentFromLocalFile
     spec:
       file: LICENSE
   URLFileMatchesSpecifiedContent:
@@ -626,13 +626,13 @@ conditions:
       line: 5 # The file './LICENSE' has a 5th line which is NOT empty
   URLFileHasLineMatchingSource:
     kind: file
-    sourceID: LineFromURL
+    sourceid: LineFromURL
     spec:
       file: https://releases.hashicorp.com/terraform/0.14.5/terraform_0.14.5_SHA256SUMS
       line: 3 # The line 3 of the file matches the source LineFromURL
   LocalFileHasLineMatchingSource:
     kind: file
-    sourceID: LineFromLocalFile
+    sourceid: LineFromLocalFile
     spec:
       file: LICENSE
       line: 3 # The file './LICENSE' has a 3rd line which is NOT empty and matches the source LineFromLocalFile
@@ -653,7 +653,7 @@ conditions:
   ## Should fail condition if uncommented
   # LocalFileHasDifferentContentAsSource:
   #   kind: file
-  #   sourceID: ContentFromURL
+  #   sourceid: ContentFromURL
   #   spec:
   #     file: LICENSE
   # URLFileDifferentThanSpecifiedContent:
@@ -672,7 +672,7 @@ conditions:
   ## Should fail validation if uncommented
   # FailsToValidateBecauseMutuallyExclusiveAttributes:
   #   kind: file
-  #   sourceID: ContentFromLocalFile
+  #   sourceid: ContentFromLocalFile
   #   spec:
   #     file: https://get.helm.sh/helm-v3.5.0-darwin-amd64.tar.gz.sha256sum
   #     content: |
@@ -680,40 +680,40 @@ conditions:
 targets:
   setFileContent:
     kind: file
-    sourceID: ContentFromURL
+    sourceid: ContentFromURL
     spec:
       file: terraform_0.14.5_SHA256SUMS
       forcecreate: true
   setLineOfFile:
     kind: file
-    sourceID: LineFromLocalFile
+    sourceid: LineFromLocalFile
     spec:
       file: LICENSE
       line: 5
   setLineOfFileWithContent:
     kind: file
-    sourceID: LineFromLocalFile
+    sourceid: LineFromLocalFile
     spec:
       file: LICENSE
       line: 3
       content: oldline was "{{ source `LineFromLocalFile` }}"
   setLineWithMatchAndReplacePatterns:
     kind: file
-    sourceID: ContentFromURL
+    sourceid: ContentFromURL
     spec:
       file: LICENSE
       matchPattern: 'Copyright \(c\) (\d*) (.*)'
       replacepattern: 'Copyright (c) 2021 $2'
   setLineWithMatchAndContent:
     kind: file
-    sourceID: ContentFromURL
+    sourceid: ContentFromURL
     spec:
       file: LICENSE
       matchPattern: 'Copyright \(c\) (\d*) (.*)'
       content: 'Copyright (c) 2021 FooBar'
   setLineWithMatchAndSource:
     kind: file
-    sourceID: ContentFromURL
+    sourceid: ContentFromURL
     spec:
       file: LICENSE
       matchPattern: 'Copyright \(c\) (\d*) (.*)'


### PR DESCRIPTION
> WARNING: "sourceID" is deprecated in favor of "sourceid".