### PR TITLE
Use matchpattern as-in schema

### DIFF
--- a/content/en/docs/plugins/resource/file.adoc
+++ b/content/en/docs/plugins/resource/file.adoc
@@ -50,8 +50,8 @@ The following parameters can be specified through the `spec` attributes map:
 | file | &#10004; | | Path to the file (either local filesystem or an URL)
 | content | | | (Only for condition and target) Expected content of the file
 | line | | | Number (integer starting at `1`) of the line to use/update in the file
-| matchPattern | | | Regex to match content in the file (https://pkg.go.dev/regexp[Golang regexp syntax])
-| replacepattern | | | (Only for target) Regex to replace content matched by `matchPattern` in the file from the `match` (https://pkg.go.dev/regexp[Golang regexp syntax])
+| matchpattern | | | Regex to match content in the file (https://pkg.go.dev/regexp[Golang regexp syntax])
+| replacepattern | | | (Only for target) Regex to replace content matched by `matchpattern` in the file from the `match` (https://pkg.go.dev/regexp[Golang regexp syntax])
 | forcecreate | | false | (Only for target) Wether to create the file if the specified location does not exist.
 |===
 
@@ -82,7 +82,7 @@ It retrieves the content of the file at the location `file` and use it as the so
 You may filter the content with one of the options below:
 
 * If the attribute `spec.line` is specified, then the source value is set to the content of this line only
-* If the attribute `spec.matchPattern` is specified, then the source value is set to the matched content in the file
+* If the attribute `spec.matchpattern` is specified, then the source value is set to the matched content in the file
 ** The specified pattern must be a valid https://pkg.go.dev/regexp[Golang regexp]
 ** When there are no matched content (e.g. the matched content is the empty string), then the source fails
 
@@ -214,7 +214,7 @@ sources:
     kind: file
     spec:
       file: https://releases.hashicorp.com/terraform/0.14.5/terraform_0.14.5_SHA256SUMS
-      matchPattern: '.*terraform_.*_linux_amd64.*'
+      matchpattern: '.*terraform_.*_linux_amd64.*'
 --
 +
 [source,shell]
@@ -261,7 +261,7 @@ Alternatively you can disable the source input value with `disablesourceinput: t
 You may filter the content of the file to be compared to the <<Input Value>> with one of the options below:
 
 * If the attribute `spec.line` is specified, then the input value is only compared to the content of this line
-* If the attribute `spec.matchPattern` is specified, then the input value is only compared to the matched content in the file
+* If the attribute `spec.matchpattern` is specified, then the input value is only compared to the matched content in the file
 ** The specified pattern must be a valid https://pkg.go.dev/regexp[Golang regexp]
 
 === Condition Examples
@@ -394,7 +394,7 @@ conditions:
     disablesourceinput: true
     spec:
       file: https://releases.hashicorp.com/terraform/0.14.5/terraform_0.14.5_SHA256SUMS
-      matchPattern: '.*terraform_.*_linux.*'
+      matchpattern: '.*terraform_.*_linux.*'
 --
 +
 [source,shell]
@@ -439,7 +439,7 @@ The "Input Value" is the string to write to the specified file.
 Using the `spec.content` is useful when you need to templatize with the source input value (see example below).
 
 * Finally, you can define a https://pkg.go.dev/regexp[Golang regexp] in the attribute `spec.ReplacePattern`,
-if and only if you also specified a `spec.matchPattern` (see <<Restricting File Content Update>> and <<Target Examples>> for more details).
+if and only if you also specified a `spec.matchpattern` (see <<Restricting File Content Update>> and <<Target Examples>> for more details).
 ** Regexp's capturing group are supported (this is the recommended use case)
 
 === Restricting File Content Update
@@ -449,7 +449,7 @@ You may restrict which part of the specified file to be updated with the input v
 * If the attribute `spec.line` is specified, then the input value is only written to the specified line.
 ** When the input value is a multi-line string, then additional lines are inserted (the 1st line of the input value is written to the specified line, and subsequent input value's lines are inserted)
 
-* If the attribute `spec.matchPattern` is specified, then all the matching patterns are replaced by the input value.
+* If the attribute `spec.matchpattern` is specified, then all the matching patterns are replaced by the input value.
 ** The specified pattern must be a valid https://pkg.go.dev/regexp[Golang regexp]
 ** As described in <<Target Input Value>>, the input value can be the input source, a content string or a regexp "replace pattern"
 ** Please note that the matched content can be a line but also a substring!
@@ -545,7 +545,7 @@ targets:
     sourceid: whateverSource # Will be ignored as `replacepattern` is specified
     spec:
       file: LICENSE
-      matchPattern: 'Copyright \(c\) (\d*) (.*)'
+      matchpattern: 'Copyright \(c\) (\d*) (.*)'
       replacepattern: 'Copyright (c) 2021 $2'
 --
 +
@@ -599,12 +599,12 @@ sources:
     kind: file
     spec:
       file: LICENSE
-      matchPattern: 'Copyright.*' # Returns a single line
+      matchpattern: 'Copyright.*' # Returns a single line
   MultipleLinesFromURLWithPattern:
     kind: file
     spec:
       file: https://releases.hashicorp.com/terraform/0.14.5/terraform_0.14.5_SHA256SUMS
-      matchPattern: '.*terraform_.*_linux.*' # Returns a multi-line content as multiple lines are matched
+      matchpattern: '.*terraform_.*_linux.*' # Returns a multi-line content as multiple lines are matched
 conditions:
   LocalFileHasSameContentAsSource:
     kind: file
@@ -648,7 +648,7 @@ conditions:
     disablesourceinput: true
     spec:
       file: "LICENSE"
-      matchPattern: 'Copyright \(c\) (\d*) Olblak'
+      matchpattern: 'Copyright \(c\) (\d*) Olblak'
   ######## Expected Failures
   ## Should fail condition if uncommented
   # LocalFileHasDifferentContentAsSource:
@@ -702,19 +702,19 @@ targets:
     sourceid: ContentFromURL
     spec:
       file: LICENSE
-      matchPattern: 'Copyright \(c\) (\d*) (.*)'
+      matchpattern: 'Copyright \(c\) (\d*) (.*)'
       replacepattern: 'Copyright (c) 2021 $2'
   setLineWithMatchAndContent:
     kind: file
     sourceid: ContentFromURL
     spec:
       file: LICENSE
-      matchPattern: 'Copyright \(c\) (\d*) (.*)'
+      matchpattern: 'Copyright \(c\) (\d*) (.*)'
       content: 'Copyright (c) 2021 FooBar'
   setLineWithMatchAndSource:
     kind: file
     sourceid: ContentFromURL
     spec:
       file: LICENSE
-      matchPattern: 'Copyright \(c\) (\d*) (.*)'
+      matchpattern: 'Copyright \(c\) (\d*) (.*)'
 ----


### PR DESCRIPTION
First issue I mentioned here is not actually a schema issue but a docs issue:
https://github.com/updatecli/updatecli/issues/866#issuecomment-1280759762

I copy pasted from the docs, and when I setup the json schema it said this was invalid. After looking around a bit I found that it's expected to be in lowercase, I did think it was weird that replacepattern used a different casing