### PR TITLE
chore:  wrong url in FAQ

### DIFF
--- a/content/en/docs/plugins/autodiscovery/others.adoc
+++ b/content/en/docs/plugins/autodiscovery/others.adoc
@@ -16,5 +16,5 @@ Are you missing something?
 
 Feel free to:
 
-- Open an new issue on link://github.com/updatecli/issues/new/choose[github.com/updatecli/]
+- Open an new issue on https://github.com/updatecli/updatecli/issues/new/choose[github.com/updatecli/updatecli]
 - Reach out via link://matrix.to/#/#Updatecli_community:gitter.im[Matrix] or link://gitter.im/Updatecli/community?utm_source=share-link&utm_medium=link&utm_campaign=share-link[Gitter]

--- a/content/en/docs/plugins/autodiscovery/others.adoc
+++ b/content/en/docs/plugins/autodiscovery/others.adoc
@@ -16,5 +16,5 @@ Are you missing something?
 
 Feel free to:
 
-- Open an new issue on link://https://github.com/updatecli/updatecli/issues/new/choose[github.com/updatecli/updatecli]
+- Open an new issue on link://github.com/updatecli/issues/new/choose[github.com/updatecli/]
 - Reach out via link://matrix.to/#/#Updatecli_community:gitter.im[Matrix] or link://gitter.im/Updatecli/community?utm_source=share-link&utm_medium=link&utm_campaign=share-link[Gitter]


### PR DESCRIPTION
here : https://www.updatecli.io/docs/plugins/autodiscovery/others/ the link for new issue is wrong.