### PR TITLE
Add `/docs/` alias to `/docs/prologue/introduction.md`

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -1,6 +1,6 @@
 baseurl = "/"
 canonifyURLs = false
-disableAliases = true
+disableAliases = false
 disableHugoGeneratorInject = true
 enableEmoji = true
 enableGitInfo = true

--- a/content/en/docs/prologue/introduction.md
+++ b/content/en/docs/prologue/introduction.md
@@ -11,6 +11,8 @@ menu:
     parent: "prologue"
 weight: 100
 toc: true
+aliases:
+- /docs/
 ---
 
 Updatecli is a command-line tool used to define and apply update strategies.


### PR DESCRIPTION
<!-- Provide a link to the issue you are solving in this pull request -->
Fix #XXX
<!-- Provide a link to the documentation related to this this pull request -->
[Documentation](https://)

## Description

This PR add an alias to https://www.updatecli.io/docs/prologue/introduction/ in order to redirect https://www.updatecli.io/docs/ to it, as the https://www.updatecli.io/docs/ is the one indexed by Google as second result on the "updatecli" search, and this long list is quite unwelcoming.

## Test

To test this pull request, you can run the following commands:

```shell
cp <to_package_directory>
go test
```

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
