### PR TITLE
Fix typo requiredEnv typo configuration.adoc

### DIFF
--- a/content/en/docs/core/configuration.adoc
+++ b/content/en/docs/core/configuration.adoc
@@ -46,7 +46,7 @@ Manifest are provided to the updatecli command using the global flag `--config <
 === Content
 
 Using go templates allows us to specify generic values in a different YAML file, using `--values`, then reference those values from each go template.
-Updatecli also provides a custom function called `requireEnv` to inject any environment variable in the template example, `{{ requiredEnv "PATH" }}`. +
+Updatecli also provides a custom function called `requiredEnv` to inject any environment variable in the template example, `{{ requiredEnv "PATH" }}`. +
 Additionally, all functions from the https://masterminds.github.io/sprig/[Sprig template library] are available.
 
 More information on Go templates can be found https://golang.org/pkg/text/template/[here].


### PR DESCRIPTION
As mentionned on the [chat](https://matrix.to/#/!TQpOBNqKouILtnYnAd:gitter.im/$5CDYaV8gKYZHHAkS7lEzkq7ePP3-bk_Vdapb3MgQDCQ?via=gitter.im&via=matrix.org&via=matrix.freyachat.eu)

There is typo in the configuration page
