### PR TITLE
fix(documentation): Adds a second example for JSON

### DIFF
--- a/assets/code_example/docs/plugins/resources/json/updatecli.d/jenkins-old-versions.yaml
+++ b/assets/code_example/docs/plugins/resources/json/updatecli.d/jenkins-old-versions.yaml
@@ -1,0 +1,104 @@
+# We're working with https://updates.jenkins.io/tiers.json
+# {"stableCores":["2.346.3","2.361.1", ...,"2.414.2"],"weeklyCores":["2.364","2.371",...,"2.425"]}
+# This example finds the oldest weekly and stable supported Jenkins versions (first in the list)
+# It also finds the latest weekly and stable Jenkins versions (last in the list)
+name: Find oldest supported Jenkins versions
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  JenkinsOldestSupportedWeekly:
+    name: Get the oldest supported Jenkins weekly version
+    kind: json
+    scmid: default
+    spec:
+      file: https://updates.jenkins.io/tiers.json
+      key: "weeklyCores.[0]"
+  JenkinsOldestSupportedStable:
+    name: Get the oldest supported Jenkins stable version
+    kind: json
+    scmid: default
+    spec:
+      file: https://updates.jenkins.io/tiers.json
+      key: "stableCores.[0]"
+  JenkinsNewestWeeklyVersion:
+    name: Get the newest supported Jenkins weekly version
+    kind: json
+    spec:
+      file: https://updates.jenkins.io/tiers.json
+      query: "weeklyCores.[*]"
+      versionfilter:
+        kind: semver
+  JenkinsNewestStableVersion:
+    name: Get the newest supported Jenkins stable version
+    kind: json
+    spec:
+      file: https://updates.jenkins.io/tiers.json
+      query: "stableCores.[*]"
+      versionfilter:
+        kind: semver
+
+conditions:
+  # Test that the oldest Jenkins supported weekly version exists
+  jenkinsOldestSupportedWeeklyVersion:
+    kind: jenkins
+    spec:
+      release: weekly
+    sourceid: JenkinsOldestSupportedWeekly
+  # Test that the oldest Jenkins supported stable version exists
+  jenkinsOldestSupportedStableVersion:
+    kind: jenkins
+    sourceid: JenkinsOldestSupportedStable
+  # Test that the newest Jenkins supported weekly version exists
+  jenkinsNewestSupportedWeeklyVersion:
+    kind: jenkins
+    spec:
+      release: weekly
+    sourceid: JenkinsNewestWeeklyVersion
+  # Test that the newest Jenkins supported stable version exists
+  jenkinsNewestSupportedStableVersion:
+    kind: jenkins
+    sourceid: JenkinsNewestStableVersion
+targets:
+  setJenkinsOldestSupportedWeekly:
+    kind: file
+    name: "Bump Jenkins oldest weekly supported version in the \"Choosing a version\" page"
+    sourceid: JenkinsOldestSupportedWeekly
+    spec:
+      file: content/doc/developer/plugin-development/choosing-jenkins-baseline.adoc
+      matchpattern: >-
+        (.*Do not use versions no longer supported by the update center.*older than )(.*)( for weekly releases.*for LTS releases.*)
+      replacepattern: >-
+        ${1}{{ source "JenkinsOldestSupportedWeekly" }}${3}
+    scmid: default
+  setJenkinsOldestSupportedStable:
+    kind: file
+    name: "Bump Jenkins oldest stable supported version in the \"Choosing a version\" page"
+    sourceid: JenkinsOldestSupportedStable
+    spec:
+      file: content/doc/developer/plugin-development/choosing-jenkins-baseline.adoc
+      matchpattern: >-
+        (.*Do not use versions no longer supported by the update center.* weekly releases, and )(.*)( for LTS releases.*)
+      replacepattern: >-
+        ${1}{{ source "JenkinsOldestSupportedStable" }}${3}
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump Jenkins LTS and weekly versions in various parts of the documentation
+    spec:
+      labels:
+        - dependencies
+        - chore

--- a/assets/code_example/docs/plugins/resources/json/updatecli.d/jenkins-old-versions.yaml
+++ b/assets/code_example/docs/plugins/resources/json/updatecli.d/jenkins-old-versions.yaml
@@ -30,13 +30,17 @@ sources:
     scmid: default
     spec:
       file: https://updates.jenkins.io/tiers.json
+      # `key` targets only one value, the first one of the list in this case
       key: "stableCores.[0]"
   JenkinsNewestWeeklyVersion:
     name: Get the newest supported Jenkins weekly version
     kind: json
     spec:
       file: https://updates.jenkins.io/tiers.json
+      # Here we use `query` to target all the values in the list
       query: "weeklyCores.[*]"
+      # We use `versionfilter` to filter the list of versions
+      # Combined with `semver`, we can target the latest version that follows the semver pattern
       versionfilter:
         kind: semver
   JenkinsNewestStableVersion:

--- a/content/en/docs/plugins/resource/json.adoc
+++ b/content/en/docs/plugins/resource/json.adoc
@@ -47,7 +47,9 @@ The JSON "target" ensures that a JSON file content a specific value at specific 
 
 The JSON plugin relies on link:https://daseldocs.tomwright.me/[Dasel] to query json files
 
-== Example
+== Examples
+
+=== Retrieves a value from a JSON file
 
 [source,yaml]
 ----
@@ -55,4 +57,10 @@ The JSON plugin relies on link:https://daseldocs.tomwright.me/[Dasel] to query j
 {{<include "assets/code_example/docs/plugins/resources/json/updatecli.d/default.yaml">}}
 ----
 
+=== Uses a path to find a value in a JSON file
 
+[source,yaml]
+----
+# jenkins-old-versions.yaml
+{{<include "assets/code_example/docs/plugins/resources/json/updatecli.d/jenkins-old-versions.yaml">}}
+----


### PR DESCRIPTION
## Description

I have added a second example manifest for JSON, after [our discussion](https://matrix.to/#/!TQpOBNqKouILtnYnAd:gitter.im/$jc0ZfxaPe0sCy3AvwiketipLFyO8R3gf86HFVU-cSdM?via=matrix.org&via=gitter.im).

My example may be too verbose. 🤔 