### PR TITLE
chore: disable policy from update-compose.yaml

### DIFF
--- a/update-compose.yaml
+++ b/update-compose.yaml
@@ -35,7 +35,8 @@ policies:
     policy: ghcr.io/updatecli/policies/npm/autodiscovery:0.6.0@sha256:a6f94de3fd9aba371ad285114f4444ea64a64524956560481f9dbbd55b157739
     values:
       - updatecli/values.d/scm.yaml
-  - name: Handle Updatecli version in GitHub action
-    policy: ghcr.io/updatecli/policies/updatecli/githubaction:0.1.0@sha256:a5b8933ebfc65ba6ea9e60927900135062a3293f18a68292431cec1e53208e3d
-    values:
-      - updatecli/values.d/scm.yaml
+  # Disabling this policy as I spotted a bug which I need to fix
+  #- name: Handle Updatecli version in GitHub action
+  #  policy: ghcr.io/updatecli/policies/updatecli/githubaction:0.1.0@sha256:a5b8933ebfc65ba6ea9e60927900135062a3293f18a68292431cec1e53208e3d
+  #  values:
+  #    - updatecli/values.d/scm.yaml


### PR DESCRIPTION
Disabling this policy until I have a fix for https://github.com/updatecli/updatecli/issues/1830