### PR TITLE
fix: moving releasepost Updatecli pipeline to a weekly schedule 2/2

### DIFF
--- a/update-compose.weekly.yaml
+++ b/update-compose.weekly.yaml
@@ -1,8 +1,4 @@
 policies:
-  - name: Update Updatecli policies
-    policy: ghcr.io/updatecli/policies/updatecli/autodiscovery:0.2.0@sha256:46e599fb7e874ee3f1c9cf5e4dd64b328a15d61d03e106176b19a07683afde29
-    values:
-      - updatecli/values.d/scm.yaml
   - name: Trigger releasepost
     policy: ghcr.io/updatecli/policies/releasepost/releasepost:0.1.0@sha256:6a8e68ae473a5dafa270650cd74fd296e61abaf4820daf4b50e0e21c8649b710
     values:

--- a/update-compose.yaml
+++ b/update-compose.yaml
@@ -16,6 +16,7 @@ policies:
     policy: ghcr.io/updatecli/policies/updatecli/autodiscovery:0.2.0@sha256:46e599fb7e874ee3f1c9cf5e4dd64b328a15d61d03e106176b19a07683afde29
     values:
       - updatecli/values.d/scm.yaml
+      - updatecli/values.d/compose.yaml
   - name: Handle HUGO version in netlify
     policy: ghcr.io/updatecli/policies/hugo/netlify:0.3.0@sha256:eff30ebc0dc129ef3b82cfbca1e5c3d9ea1014f360f4c51b04ea4b0f951bae91
     values:

--- a/updatecli/values.d/compose.yaml
+++ b/updatecli/values.d/compose.yaml
@@ -1,0 +1,4 @@
+spec:
+  files:
+    - "update-compose.yaml"
+    - "update-compose.weekly.yaml"


### PR DESCRIPTION
Follow up of https://github.com/updatecli/website/pull/1321

This pullrequest relies on https://github.com/updatecli/updatecli/pull/1921 to be available in release