### PR TITLE
Clarify captureindex behavior

### DIFF
--- a/content/en/docs/core/transformer.adoc
+++ b/content/en/docs/core/transformer.adoc
@@ -66,7 +66,7 @@ A replacer rule modifies the information by replacing the "from" value by the "t
 
 === FindSubMatch
 
-A `findsubmatch` rule captures the desired information by applying `pattern`` as a regexp and using `captureindex`` value as the index for the capture to return (defaults to 0).
+A `findsubmatch` rule captures the desired information by applying `pattern` as a regexp and using `captureindex` value as the index for the capture to return (defaults to 0 which returns all submatches).
 
 [cols="1,1,1,4",options=header]
 |===


### PR DESCRIPTION
Minor fixes to captureindex behaviour with `0` as index.