### PR TITLE
feat: add initial documentation for temurin-adoptium plugin

### DIFF
--- a/assets/code_example/docs/plugins/resources/temurin/updatecli.d/default.yaml
+++ b/assets/code_example/docs/plugins/resources/temurin/updatecli.d/default.yaml
@@ -1,0 +1,48 @@
+sources:
+  ## Returns the latest LTS version
+  getLatestLtsVersion:
+    kind: temurin
+
+  ## Returns the latest feature release
+  getLatestFeatureVersion:
+    kind: temurin
+    spec:
+      releaseline: feature
+
+  ## Returns the latest LTS "nightly build" (Early Availability) version
+  getLatestLtsEarlyAvailabilityVersion:
+    kind: temurin
+    spec:
+      releaseline: lts
+      releasetype: ea
+
+  ## Returns the latest "Valhalla" Project JDK 17 version available for Windows
+  getLatestWindowsValhalla17Version:
+    kind: temurin
+    spec:
+      featureversion: 17
+      project: valhalla
+      operatingsystem: windows
+
+  # Returns the latest installer URL for Linux x64
+  getLatestLTSLinuxAMD64InstallerURL:
+    kind: temurin
+    spec:
+      result: installer_url
+
+  ## Returns the latest LTS Installer's checksum URL for s390x Alpine Linux JRE
+  getLatestJRE17LinuxS390xChecksumUrl:
+    kind: temurin
+    spec:
+      operatingsystem: alpine-linux
+      architecture: s390x
+      imagetype: jre
+      result: checksum_url
+
+  ## Returns latest Installer's Signature URL of the Windows JDK version "17.0.2*"
+  getLatestCustomVersionWindowsSignatureUrl:
+    kind: temurin
+    spec:
+      version: "17.0.2"
+      operatingsystem: windows
+      result: signature_url

--- a/content/en/docs/plugins/resource/temurin.adoc
+++ b/content/en/docs/plugins/resource/temurin.adoc
@@ -1,0 +1,50 @@
+---
+title: "Temurin/Adoptium"
+description: "Retrieve Adoptium Temurin release name or installer"
+lead: "kind: temurin"
+date: 2024-08-26T15:00:00+01:00
+draft: false
+images: []
+menu:
+  docs:
+    parent: "plugin-resource"
+toc: true
+plugins:
+  - source
+---
+// <!-- Required for asciidoctor -->
+:toc:
+// Set toclevels to be at least your hugo [markup.tableOfContents.endLevel] config key
+:toclevels: 4
+
+[cols="1^,1^,1^",options=header]
+|===
+| source | condition | target
+| &#10004; | &#10007; | &#10007;
+|===
+
+== Description
+
+**source**
+
+The Temurin (Adoptium) "source" retrieves a release name, Installer URL, Checskum URL or signature URL from Adoptium (link:https://adoptium.net/[]) using their API (link:https://api.adoptium.net/[]).
+
+**condition**
+
+Unsupported
+
+**target**
+
+Unsupported
+
+== Parameter
+
+{{< resourceparameters "sources" "temurin" >}}
+
+== Example
+
+[source,yaml]
+----
+# updatecli.yaml
+{{<include "assets/code_example/docs/plugins/resources/temurin/updatecli.d/default.yaml">}}
+----


### PR DESCRIPTION
This PR adds the initial documentation for the `temurin` resource introduced in https://github.com/updatecli/updatecli/pull/2556

