### PR TITLE
Bump maven docs

### DIFF
--- a/assets/code_example/docs/plugins/resources/maven/updatecli.d/default.yaml
+++ b/assets/code_example/docs/plugins/resources/maven/updatecli.d/default.yaml
@@ -14,7 +14,7 @@ sources:
   default:
     kind: maven
     spec:
-      # optionally provide credentials as user:pass@hostname,
+      # optionally provide credentials as user:pass@hostname
       # using requiredEnv custom function
       repository: "repo.jenkins-ci.org/releases"
       groupid: "org.jenkins-ci.main"

--- a/assets/code_example/docs/plugins/resources/maven/updatecli.d/default.yaml
+++ b/assets/code_example/docs/plugins/resources/maven/updatecli.d/default.yaml
@@ -14,8 +14,9 @@ sources:
   default:
     kind: maven
     spec:
-      url: "repo.jenkins-ci.org"
-      repository: "releases"
+      # optionally provide credentials as user:pass@hostname,
+      # using requiredEnv custom function
+      repository: "repo.jenkins-ci.org/releases"
       groupid: "org.jenkins-ci.main"
       artifactid: "jenkins-war"
     transformers:

--- a/content/en/docs/plugins/resource/maven.adoc
+++ b/content/en/docs/plugins/resource/maven.adoc
@@ -39,7 +39,7 @@ The maven "condition" tests if a version exist on a maven repository.
 
 {{< resourceparameters "sources" "maven" >}}
 
-NOTE: Url can contain Basic Auth credentials following the standard notation: `username:password@url`
+NOTE: `repository` can contain Basic Auth credentials following the standard notation: `username:password@hostname`
 
 == Example
 


### PR DESCRIPTION
`url` has been deprecated in maven plugin, hostname should be provided in repository field.
Added comment to document how to provide basic auth credentials