### PR TITLE
Fix for invalid regex pattern

### DIFF
--- a/content/en/docs/plugins/_versionFilter.adoc
+++ b/content/en/docs/plugins/_versionFilter.adoc
@@ -41,11 +41,11 @@ sources:
       username: "john"
       versionFilter:
         kind: regex
-        pattern: "kubernetes-1.(\d*).(\d*)$"
+        pattern: "kubernetes-1.(\\d*).(\\d*)$"
     transformers:
       - trimPrefix: "kubernetes-"
 ```
-=> Return the newest kubectl version matching pattern "kubernetes-1.(\d*).(\d*)$" and remove "kubernetes-" from it
+=> Return the newest kubectl version matching pattern "kubernetes-1.(\\d*).(\\d*)$" and remove "kubernetes-" from it
 
 ==== semver
 


### PR DESCRIPTION
Fix for invalid regex pattern in docs ex. https://www.updatecli.io/docs/plugins/resource/github_release/

If you try to use the previous pattern you will get an error ```yaml: line 14: found unknown escape character```