### PR TITLE
Fix out-of-date `kind` field for GitHub Pull Request code examples

### DIFF
--- a/assets/code_example/docs/plugins/actions/github_pullrequest/updatecli.yaml
+++ b/assets/code_example/docs/plugins/actions/github_pullrequest/updatecli.yaml
@@ -15,7 +15,7 @@ scms:
 # Define action configurations if one needs to be created
 actions:
   helm-charts:
-    kind: "github"
+    kind: "github/pullrequest"
     scmid: "website"
     spec:
       automerge: true

--- a/assets/code_example/docs/plugins/autodiscovery/fleet/updatecli.d/default.yaml
+++ b/assets/code_example/docs/plugins/autodiscovery/fleet/updatecli.d/default.yaml
@@ -11,7 +11,7 @@ scms:
 
 actions:
   fleet-lab:
-    kind: github
+    kind: github/pullrequest
     scmid: fleet-lab
     spec:
       labels:


### PR DESCRIPTION
Update the example documentation for the [Github Pull Request action example documentation](https://www.updatecli.io/docs/plugins/actions/github/#_example) to reflect the new `kind` value of `github/pullrequest` for that action type.

This new value [is taken from the schema that VSCode consumes.](https://www.updatecli.io/schema/latest/policy/manifest/config.json)

When used, the old value of `github` produces a warning:

```
WARNING: The kind "github" for actions is deprecated in favor of 'github/pullrequest'
```

## Test
Searched for `kind: github$` in non-`.adoc` files throughout the repository and updated relevant entries.

Checked both updated pages in the netlify preview:
- [PR action docs](https://deploy-preview-2050--amazing-golick-2d0138.netlify.app/docs/plugins/actions/github/)
- [Fleet autodiscovery docs](https://deploy-preview-2050--amazing-golick-2d0138.netlify.app/docs/plugins/autodiscovery/fleet/)
## Additional Information

### Tradeoff

Users on old versions of `updatecli` may encounter fatal errors when using the new value. They can fix that by updating to the latest version of `updatecli`.

### Potential improvement

Maybe it's worth updating the old blog articles that reference the old`kind: github` value, but that is debatable.