### PR TITLE
fix url to linux tgz in  installation.adoc

### DIFF
--- a/content/en/docs/prologue/installation.adoc
+++ b/content/en/docs/prologue/installation.adoc
@@ -89,11 +89,14 @@ yay -S updatecli-bin
 [source,shell]
 ```
 # amd64
-curl -sL -o/tmp/updatecli_amd64.tgz https://github.com/updatecli/updatecli/releases/download/v0.106.0/updatecli_amd64.tgz
+curl -sL -o/tmp/updatecli_amd64.tgz https://github.com/updatecli/updatecli/releases/download/v0.106.0/updatecli_Linux_x86_64.tar.gz
+
 # arm64
-curl -sL -o/tmp/updatecli_arm64.tgz https://github.com/updatecli/updatecli/releases/download/v0.106.0/updatecli_arm64.tgz
+curl -sL -o/tmp/updatecli_arm64.tgz https://github.com/updatecli/updatecli/releases/download/v0.106.0/updatecli_Linux_x86_64.tar.gz
+
 # armv6
-curl -sL -o/tmp/updatecli_armv6.tgz https://github.com/updatecli/updatecli/releases/download/v0.106.0/updatecli_armv6.tgz
+curl -sL -o/tmp/updatecli_armv6.tgz https://github.com/updatecli/updatecli/releases/download/v0.106.0/updatecli_Linux_x86_64.tar.gz
+
 ```
 
 == Docker


### PR DESCRIPTION
thx for your work

Fix:

paths to tgz was wrong

Potential improvement:

for each path to make curl check e.g.

```
 if ! curl --head --fail -v https://github.com/updatecli/updatecli/releases/download/v0.106.0/updatecli_Linux_x86_64.tar.gz ; then 
   echo "ERROR URL is wrong"
   exit 1 
fi
```
