### PR TITLE
Remove GITHUB_TOKEN requirement from Updatecli policies

### DIFF
--- a/updatecli/updatecli.d/docs.yaml
+++ b/updatecli/updatecli.d/docs.yaml
@@ -1,42 +1,40 @@
-name: 'docs: update Updatecli cli documentation'
+name: "docs: update Updatecli cli documentation"
 
 pipelineid: cli_docs
 
 actions:
-    default:
-        kind: github/pullrequest
-        spec:
-            automerge: true
-            reviewers:
-              - updatecli/core
-            labels:
-                - chore
-            mergemethod: squash
-        scmid: default
+  default:
+    kind: github/pullrequest
+    spec:
+      automerge: true
+      reviewers:
+        - updatecli/core
+      labels:
+        - chore
+      mergemethod: squash
+    scmid: default
 
 scms:
-    default:
-        kind: github
-        spec:
-            branch: master
-            email: updatecli@olblak.com
-            owner: updatecli
-            repository: website
-            token: '{{ requiredEnv "GITHUB_TOKEN" }}'
-            user: updatecli
-            username: '{{ requiredEnv "GITHUB_ACTOR" }}'
-            force: true
-            commitusingapi: true
-        disabled: false
+  default:
+    kind: github
+    spec:
+      branch: master
+      email: updatecli@olblak.com
+      owner: updatecli
+      repository: website
+      user: updatecli
+      force: true
+      commitusingapi: true
+    disabled: false
 
 targets:
-    jsonschema:
-        name: 'docs: update updatecli cli documentation'
-        kind: shell
-        spec:
-            command: updatecli docs -d ./content/en/docs/commands
-            environments:
-                - name: PATH
-        scmid: default
+  jsonschema:
+    name: "docs: update updatecli cli documentation"
+    kind: shell
+    spec:
+      command: updatecli docs -d ./content/en/docs/commands
+      environments:
+        - name: PATH
+    scmid: default
 
-version: "0.64.1"
+version: "0.109.0"

--- a/updatecli/updatecli.d/installation.yaml
+++ b/updatecli/updatecli.d/installation.yaml
@@ -1,51 +1,47 @@
-name: 'docs: update Updatecli version throughout the documentation'
+name: "docs: update Updatecli version throughout the documentation"
 pipelineid: updatecli/version
 
 actions:
-    default:
-        kind: github/pullrequest
-        spec:
-            automerge: true
-            reviewers:
-              - updatecli/core
-            labels:
-                - chore
-            mergemethod: squash
-        scmid: default
+  default:
+    kind: github/pullrequest
+    spec:
+      automerge: true
+      reviewers:
+        - updatecli/core
+      labels:
+        - chore
+      mergemethod: squash
+    scmid: default
 
 scms:
-    default:
-        kind: github
-        spec:
-            branch: master
-            email: updatecli@olblak.com
-            owner: updatecli
-            repository: website
-            token: '{{ requiredEnv "GITHUB_TOKEN" }}'
-            user: updatecli
-            username: '{{ requiredEnv "GITHUB_ACTOR" }}'
-            commitusingapi: true
-        disabled: false
+  default:
+    kind: github
+    spec:
+      branch: master
+      email: updatecli@olblak.com
+      owner: updatecli
+      repository: website
+      user: updatecli
+      commitusingapi: true
+    disabled: false
 
 sources:
-    updatecli:
-        name: Get latest updatecli release
-        kind: githubrelease
-        spec:
-            owner: updatecli
-            repository: updatecli
-            token: '{{ requiredEnv "GITHUB_TOKEN" }}'
-            username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+  updatecli:
+    name: Get latest updatecli release
+    kind: githubrelease
+    spec:
+      owner: updatecli
+      repository: updatecli
 
 targets:
-    download-url:
-        name: 'docs: update updatecli version to {{ source "updatecli" }}'
-        kind: file
-        spec:
-            file: content/en/docs/prologue/installation.adoc
-            matchpattern: https://github.com/updatecli/updatecli/releases/download/(.*)/
-            replacepattern: https://github.com/updatecli/updatecli/releases/download/{{ source "updatecli" }}/
-        scmid: default
-        sourceid: updatecli
+  download-url:
+    name: 'docs: update updatecli version to {{ source "updatecli" }}'
+    kind: file
+    spec:
+      file: content/en/docs/prologue/installation.adoc
+      matchpattern: https://github.com/updatecli/updatecli/releases/download/(.*)/
+      replacepattern: https://github.com/updatecli/updatecli/releases/download/{{ source "updatecli" }}/
+    scmid: default
+    sourceid: updatecli
 
-version: 0.64.1
+version: 0.109.0

--- a/updatecli/updatecli.d/jsonschema.yaml
+++ b/updatecli/updatecli.d/jsonschema.yaml
@@ -1,51 +1,49 @@
 pipelineid: jsonschema
-name: 'docs: update Updatecli jsonschema'
+name: "docs: update Updatecli jsonschema"
 
 actions:
-    default:
-        kind: github/pullrequest
-        spec:
-            automerge: true
-            reviewers:
-              - updatecli/core
-            labels:
-                - chore
-                - documentation
-            mergemethod: squash
-        scmid: default
+  default:
+    kind: github/pullrequest
+    spec:
+      automerge: true
+      reviewers:
+        - updatecli/core
+      labels:
+        - chore
+        - documentation
+      mergemethod: squash
+    scmid: default
 
 scms:
-    default:
-        kind: github
-        spec:
-            branch: master
-            email: updatecli@olblak.com
-            owner: updatecli
-            repository: website
-            token: '{{ requiredEnv "GITHUB_TOKEN" }}'
-            user: updatecli
-            username: '{{ requiredEnv "GITHUB_ACTOR" }}'
-            commitusingapi: true
-        disabled: false
+  default:
+    kind: github
+    spec:
+      branch: master
+      email: updatecli@olblak.com
+      owner: updatecli
+      repository: website
+      user: updatecli
+      commitusingapi: true
+    disabled: false
 
 targets:
-    jsonschema:
-        name: 'chore: update Updatecli jsonschema'
-        kind: shell
+  jsonschema:
+    name: "chore: update Updatecli jsonschema"
+    kind: shell
+    spec:
+      changedif:
+        kind: file/checksum
         spec:
-            changedif:
-                kind: file/checksum
-                spec:
-                  files:
-                    - content/en/schema/latest/config.json
-                    - content/en/schema/latest/compose/config.json
-                    - content/en/schema/latest/policy/manifest/config.json
-                    - content/en/schema/latest/policy/metadata/config.json
-            command: |
-                updatecli jsonschema --baseid https://www.updatecli.io/latest/schema --directory content/en/schema/latest
+          files:
+            - content/en/schema/latest/config.json
+            - content/en/schema/latest/compose/config.json
+            - content/en/schema/latest/policy/manifest/config.json
+            - content/en/schema/latest/policy/metadata/config.json
+      command: |
+        updatecli jsonschema --baseid https://www.updatecli.io/latest/schema --directory content/en/schema/latest
 
-            environments:
-               - name: PATH
-        scmid: default
+      environments:
+        - name: PATH
+    scmid: default
 
-version: 0.64.1
+version: 0.109.0


### PR DESCRIPTION
Remove GITHUB_TOKEN requirement from Updatecli policies

<!-- Describe the changes introduced by this pull request -->

## Test

This project uses Netlify to generate preview environment,
so feel free to look there directly to see how this pullrequest render

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
